### PR TITLE
Fixes for microphone example on Windows

### DIFF
--- a/examples/usb_microphone/tusb_config.h
+++ b/examples/usb_microphone/tusb_config.h
@@ -100,9 +100,9 @@ extern "C" {
 #define CFG_TUD_AUDIO_ENABLE_EP_IN                                    1
 #define CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX                    2                                       // Driver gets this info from the descriptors - we define it here to use it to setup the descriptors and to do calculations with it below
 #define CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX                            1                                       // Driver gets this info from the descriptors - we define it here to use it to setup the descriptors and to do calculations with it below - be aware: for different number of channels you need another descriptor!
-#define CFG_TUD_AUDIO_EP_SZ_IN                                        16 * CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX      // 16 Samples (16 kHz) x 2 Bytes/Sample x 1 Channel
+#define CFG_TUD_AUDIO_EP_SZ_IN                                        (16 + 1) * CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX * CFG_TUD_AUDIO_FUNC_1_N_CHANNELS_TX      // 16 Samples (16 kHz) x 2 Bytes/Sample x 1 Channel
 #define CFG_TUD_AUDIO_FUNC_1_EP_IN_SZ_MAX                             CFG_TUD_AUDIO_EP_SZ_IN                  // Maximum EP IN size for all AS alternate settings used
-#define CFG_TUD_AUDIO_FUNC_1_EP_IN_SW_BUF_SZ                          CFG_TUD_AUDIO_EP_SZ_IN + 1
+#define CFG_TUD_AUDIO_FUNC_1_EP_IN_SW_BUF_SZ                          CFG_TUD_AUDIO_EP_SZ_IN
 
 #ifdef __cplusplus
 }

--- a/examples/usb_microphone/usb_descriptors.c
+++ b/examples/usb_microphone/usb_descriptors.c
@@ -92,7 +92,7 @@ enum
 uint8_t const desc_configuration[] =
 {
     // Interface count, string index, total length, attribute, power in mA
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
 
     // Interface number, string index, EP Out & EP In address, EP size
     TUD_AUDIO_MIC_ONE_CH_DESCRIPTOR(/*_itfnum*/ ITF_NUM_AUDIO_CONTROL, /*_stridx*/ 0, /*_nBytesPerSample*/ CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX, /*_nBitsUsedPerSample*/ CFG_TUD_AUDIO_FUNC_1_N_BYTES_PER_SAMPLE_TX*8, /*_epin*/ 0x80 | EPNUM_AUDIO, /*_epsize*/ CFG_TUD_AUDIO_EP_SZ_IN)

--- a/examples/usb_microphone/usb_microphone.h
+++ b/examples/usb_microphone/usb_microphone.h
@@ -11,11 +11,11 @@
 #include "tusb.h"
 
 #ifndef SAMPLE_RATE
-#define SAMPLE_RATE (CFG_TUD_AUDIO_EP_SZ_IN / 2) * 1000
+#define SAMPLE_RATE ((CFG_TUD_AUDIO_EP_SZ_IN / 2) - 1) * 1000
 #endif
 
 #ifndef SAMPLE_BUFFER_SIZE
-#define SAMPLE_BUFFER_SIZE (CFG_TUD_AUDIO_EP_SZ_IN/2)
+#define SAMPLE_BUFFER_SIZE ((CFG_TUD_AUDIO_EP_SZ_IN/2) - 1)
 #endif
 
 typedef void (*usb_microphone_tx_ready_handler_t)(void);


### PR DESCRIPTION
These changes should resolve #6.

They include:

1) a port of https://github.com/hathach/tinyusb/pull/1058

2) bumping `CFG_TUD_AUDIO_EP_SZ_IN` by one, as per the comment in: https://github.com/hathach/tinyusb/blob/2eaf99e0aa9c10d62dd8d0a4e765f5941bfeaf98/examples/device/audio_4_channel_mic/src/tusb_config.h#L104
```c
// 48 Samples (48 kHz) x 2 Bytes/Sample x CFG_TUD_AUDIO_N_CHANNELS_TX Channels
// - the Windows driver always needs an extra sample per channel of space more, otherwise it complains... found by trial and error

```

So far, I've tested on a Windows 10 VM and macOS - they seem ok.  @iovsiann it would be great if you can test these changes on Windows and Linux and report your feedback.